### PR TITLE
Add manifests for deploying Elasticsearch Exporter to PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# data.gov.uk Publish Elasticsearch Metrics Exporter
+
+The repository contains the deployment manifests to expose Elasticsearch queue metrics for data.gov.uk Publish.
+
+It relies on the deployment of [Elasticseach Exporter](https://github.com/alphagov/datagovuk_publish_elasticsearch_monitor) (a Go application) to deal create an endpoint that can be accessed by Prometheus.
+
+## Getting Started
+
+This app is deployed on the PaaS.
+
+```
+git clone https://github.com/justwatchcom/elasticsearch_exporter
+cf push -p elasticsearch_exporter -f manifest-staging.yml
+cf push -p elasticsearch_exporter -f manifest-production.yml
+```
+
+The metrics are accessible online at https://publish-data-staging-elasticsearch-monitor.cloudapps.digital/metrics and https://publish-data-production-elasticsearch-monitor.cloudapps.digital/metrics.
+

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -1,0 +1,12 @@
+---
+applications:
+  - name: publish-data-production-elasticsearch-monitor
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -web.listen-address "0.0.0.0:$PORT"
+    memory: 512M
+    buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    env:
+      GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter
+    services:
+    - publish-production-secrets
+    - elasticsearch-beta-production
+    - re-ip-whitelist-service

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,0 +1,12 @@
+---
+applications:
+  - name: publish-data-staging-elasticsearch-monitor
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -web.listen-address "0.0.0.0:$PORT"
+    memory: 512M
+    buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    env:
+      GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter
+    services:
+    - publish-staging-secrets
+    - elasticsearch-beta-staging
+    - re-ip-whitelist-service


### PR DESCRIPTION
Manifests for deploying [Elasticseach Exporter](https://github.com/alphagov/datagovuk_publish_elasticsearch_monitor) (a Go application) to the PaaS for data.gov.uk.

Trello card: https://trello.com/c/tMxktv9p/440-add-an-alert-for-significant-data-size-changes-in-dgu-elasticsearch 