### PR TITLE
Bind the service to Prometheus

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -10,3 +10,4 @@ applications:
     - publish-production-secrets
     - elasticsearch-beta-production
     - re-ip-whitelist-service
+    - dgu-prometheus

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -10,3 +10,4 @@ applications:
     - publish-staging-secrets
     - elasticsearch-beta-staging
     - re-ip-whitelist-service
+    - dgu-prometheus


### PR DESCRIPTION
Binds the Prometheus service, so we can add the metrics to our alerting and dashboards.