### PR TITLE
Collect metrics for all Elasticsearch nodes

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: publish-data-production-elasticsearch-monitor
-    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -web.listen-address "0.0.0.0:$PORT"
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
     env:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: publish-data-staging-elasticsearch-monitor
-    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -web.listen-address "0.0.0.0:$PORT"
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
     env:


### PR DESCRIPTION
At the moment we only collect stats on the node that we end up connecting to, and as that changes, the stats we're getting back end up being slightly different and jump around as the nodes sync up.

After this we will change the alert to take an average across all the nodes.

[Trello Card](https://trello.com/c/o34SAzlN/467-review-the-dgu-index-size-alert-and-dashboard-graph)