### PR TITLE
Use cflinuxfs3 stack

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,6 +4,7 @@ applications:
     command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    stack: cflinuxfs3
     env:
       GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter
     services:

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -3,7 +3,8 @@ applications:
   - name: publish-data-production-elasticsearch-monitor
     command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
-    buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    buildpacks:
+      - https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
     stack: cflinuxfs3
     env:
       GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: publish-data-production-elasticsearch-monitor
-    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter --es.uri $URI --es.all --web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpacks:
       - https://github.com/cloudfoundry/go-buildpack.git#v1.8.26

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,6 +4,7 @@ applications:
     command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    stack: cflinuxfs3
     env:
       GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter
     services:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: publish-data-staging-elasticsearch-monitor
-    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
+    command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter --es.uri $URI --es.all --web.listen-address "0.0.0.0:$PORT"
     memory: 512M
     buildpacks:
       - https://github.com/cloudfoundry/go-buildpack.git#v1.8.26

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -3,7 +3,8 @@ applications:
   - name: publish-data-staging-elasticsearch-monitor
     command: URI=$(python -c "import os, json; print(json.loads(os.environ['VCAP_SERVICES'])['elasticsearch'][0]['credentials']['uri'])") && elasticsearch_exporter -es.uri $URI -es.all -web.listen-address "0.0.0.0:$PORT"
     memory: 512M
-    buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
+    buildpacks:
+      - https://github.com/cloudfoundry/go-buildpack.git#v1.8.26
     stack: cflinuxfs3
     env:
       GOPACKAGENAME: github.com/justwatchcom/elasticsearch_exporter


### PR DESCRIPTION
cflinuxfs2 is being deprecated so we should upgrade to the latest stack version.

[Trello Card](https://trello.com/c/LnfsfS1q/875-upgrade-datagovuk-to-cflinuxfs3)