### PR TITLE
Add retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> data.gov.uk Publish Elasticsearch Metrics Exporter is retired
+
 # data.gov.uk Publish Elasticsearch Metrics Exporter
 
 The repository contains the deployment manifests to expose Elasticsearch queue metrics for data.gov.uk Publish.


### PR DESCRIPTION
This app used to be used for monitoring the Elasticsearch queue pre-replatforming. It is no longer used, and its days are numbered as the GOV.UK PaaS is being switched off in December 2023

The application was stopped and deleted.

https://trello.com/c/NikGC9ja/3319-retire-datagovukpublishelasticsearchmonitor-2